### PR TITLE
Transfer class name to log file for ILogger; Convert Log4NetAsynchLog to static; Simplified direct calls; Console logging removed;

### DIFF
--- a/Logging/log4Net/Log4NetExtensions.cs
+++ b/Logging/log4Net/Log4NetExtensions.cs
@@ -9,21 +9,12 @@ namespace NZ01
 {
     public static class Log4netExtensions
     {
-        public static int CountCalls_AddLog4Net1 { get; set; } = 0;
-        public static int CountCalls_AddLog4Net2 { get; set; } = 0;
-
+        public static int CountCalls_AddLog4Net { get; set; } = 0;
 
         public static ILoggerFactory AddLog4Net(this ILoggerFactory factory)
         {
-            ++CountCalls_AddLog4Net1;
-            factory.AddProvider(new Log4NetProvider("./Logging/log4Net/log4net.config"));
-            return factory;
-        }
-
-        public static ILoggerFactory AddLog4Net(this ILoggerFactory factory, string log4NetConfigFile)
-        {
-            ++CountCalls_AddLog4Net2;
-            factory.AddProvider(new Log4NetProvider(log4NetConfigFile));
+            ++CountCalls_AddLog4Net;
+            factory.AddProvider(new Log4NetProvider("App"));
             return factory;
         }
     }

--- a/Logging/log4Net/Log4NetLogger.cs
+++ b/Logging/log4Net/Log4NetLogger.cs
@@ -4,24 +4,23 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging; // ILogger
-using System.Xml; // XmlElement
 using System.Text;
 
 namespace NZ01
 {
     public class Log4NetLogger : ILogger
     {
-        private readonly Log4NetAsyncLog _log;
+        private string _name;
 
         public static int CountCalls_InstanceCtor { get; set; } = 0;
         public static int CountCalls_BeginScope { get; set; } = 0;
         public static int CountCalls_IsEnabled { get; set; } = 0;
         public static int CountCalls_Log { get; set; } = 0;
 
-        public Log4NetLogger(string name, XmlElement xmlElement)
+        public Log4NetLogger(string name)
         {
             ++CountCalls_InstanceCtor;
-            _log = new Log4NetAsyncLog(name, xmlElement);
+            _name = name;
         }
 
         public IDisposable BeginScope<TState>(TState state) { ++CountCalls_BeginScope; return null; }
@@ -32,16 +31,16 @@ namespace NZ01
             switch (logLevel)
             {
                 case LogLevel.Critical:
-                    return _log.IsFatalEnabled;
+                    return Log4NetAsyncLog.IsFatalEnabled;
                 case LogLevel.Debug:
                 case LogLevel.Trace:
-                    return _log.IsDebugEnabled;
+                    return Log4NetAsyncLog.IsDebugEnabled;
                 case LogLevel.Error:
-                    return _log.IsErrorEnabled;
+                    return Log4NetAsyncLog.IsErrorEnabled;
                 case LogLevel.Information:
-                    return _log.IsInfoEnabled;
+                    return Log4NetAsyncLog.IsInfoEnabled;
                 case LogLevel.Warning:
-                    return _log.IsWarnEnabled;
+                    return Log4NetAsyncLog.IsWarnEnabled;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(logLevel));
             }
@@ -70,7 +69,7 @@ namespace NZ01
 
             if (state != null || exception != null)
             {
-                _log.Enqueue(logLevel, eventId, (object)state, exception, formatter, state.GetType());
+                Log4NetAsyncLog.Enqueue(logLevel, eventId, (object)state, exception, formatter, state.GetType(), _name);
             }
         }
     }

--- a/Logging/log4Net/Log4NetProvider.cs
+++ b/Logging/log4Net/Log4NetProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,46 +6,47 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging; // ILoggerProvider 
 using System.Xml; // XmlElement
 using System.IO; // File
+using System.Collections.Concurrent;
 
 
 namespace NZ01
 {
     public class Log4NetProvider : ILoggerProvider
     {
-        private Log4NetLogger _logger;
+        private Dictionary<string, Log4NetLogger> _registry = new Dictionary<string, Log4NetLogger>();
+        private bool _bRunning = true;
 
         // DIAGS
         public static int CountCalls_InstanceCtor { get; set; } = 0;
         public static int CountCalls_CreateLogger { get; set; } = 0;
         public static int CountCalls_Dispose { get; set; } = 0;
-        public static int CountCalls_parseLog4NetConfigFile { get; set; } = 0;
 
 
         // Ctor
-        public Log4NetProvider(string log4NetConfigFile)
+        public Log4NetProvider(string name)
         {
             ++CountCalls_InstanceCtor;
-            _logger = new Log4NetLogger("App", parseLog4NetConfigFile(log4NetConfigFile));
         }
 
         public ILogger CreateLogger(string categoryName)
         {
             ++CountCalls_CreateLogger;
-            return _logger;
+
+            if (!_bRunning)
+                return null;
+
+            Log4NetLogger logger = null;
+            if (!_registry.TryGetValue(categoryName, out logger))
+                logger = new Log4NetLogger(categoryName);
+
+            return logger;
         }
 
         public void Dispose()
         {
-            ++CountCalls_Dispose;            
-            _logger = null;
+            ++CountCalls_Dispose;
+            _bRunning = false;
+            _registry.Clear();
         }
-
-        private static XmlElement parseLog4NetConfigFile(string filename)
-        {
-            ++CountCalls_parseLog4NetConfigFile;
-            XmlDocument log4netConfig = new XmlDocument();
-            log4netConfig.Load(File.OpenRead(filename));
-            return log4netConfig["log4net"];
-        }
-    }
+    }    
 }

--- a/Logging/log4Net/log4Net.config
+++ b/Logging/log4Net/log4Net.config
@@ -7,14 +7,14 @@
     </root>
 
     <appender name="LogFileAppender" type="log4net.Appender.RollingFileAppender">
-      <file type="log4net.Util.PatternString" value="./Logs/AppLog-%date{yyyyMMdd-HHmmss}.log" />
+      <file type="log4net.Util.PatternString" value="./Logs/App-%date{yyyyMMdd-HHmmss}.log" />
       <appendToFile value="false" />
       <rollingStyle value="Once" />
       <maxSizeRollBackups value="-1" />
       <staticLogFileName value="true" />
       <layout type="log4net.Layout.PatternLayout" >
         <header value="[Header][%property{log4net:HostName}]&#xD;&#xA;" type="log4net.Util.PatternString"/>
-        <conversionPattern value="LOC=%date{yyyyMMdd-HH:mm:ss.fff},UTC=%utcdate{yyyyMMdd-HH:mm:ss.fff},DELTA=%10timestamp,THR=%thread,%-5level,LOG=%logger,%message%newline" />
+        <conversionPattern value="LOC=%date{yyyyMMdd-HH:mm:ss.fff},UTC=%utcdate{yyyyMMdd-HH:mm:ss.fff},DELTA=%10timestamp,THR=%thread,%-5level,%message%newline" />
       </layout>
     </appender>
 

--- a/Logging/log4Net/log4Net_DateLogFile.config
+++ b/Logging/log4Net/log4Net_DateLogFile.config
@@ -5,14 +5,14 @@
     </root>
 
     <appender name="LogFileAppender" type="log4net.Appender.RollingFileAppender">
-      <file type="log4net.Util.PatternString" value="./Logs/AppLog-%date{yyyyMMdd-HHmmss}.log" />
+      <file type="log4net.Util.PatternString" value="./Logs/App-%date{yyyyMMdd-HHmmss}.log" />
       <appendToFile value="false" />
       <rollingStyle value="Once" />
       <maxSizeRollBackups value="-1" />
       <staticLogFileName value="true" />
       <layout type="log4net.Layout.PatternLayout" >
         <header value="[Header][%property{log4net:HostName}]&#xD;&#xA;" type="log4net.Util.PatternString"/>
-        <conversionPattern value="LOC=%date{yyyyMMdd-HH:mm:ss.fff},UTC=%utcdate{yyyyMMdd-HH:mm:ss.fff},DELTA=%10timestamp,THR=%thread,%-5level,LOG=%logger,%message%newline" />
+        <conversionPattern value="LOC=%date{yyyyMMdd-HH:mm:ss.fff},UTC=%utcdate{yyyyMMdd-HH:mm:ss.fff},DELTA=%10timestamp,THR=%thread,%-5level,%message%newline" />
       </layout>
     </appender>
 

--- a/Logging/log4Net/log4Net_SameFileEachRun.config
+++ b/Logging/log4Net/log4Net_SameFileEachRun.config
@@ -13,7 +13,7 @@
       <staticLogFileName value="true" />
       <layout type="log4net.Layout.PatternLayout" >
         <header value="[Header][%property{log4net:HostName}]&#xD;&#xA;" type="log4net.Util.PatternString"/>
-        <conversionPattern value="LOC=%date{yyyyMMdd-HH:mm:ss.fff},UTC=%utcdate{yyyyMMdd-HH:mm:ss.fff},DELTA=%10timestamp,THR=%thread,%-5level,LOG=%logger,%message%newline" />
+        <conversionPattern value="LOC=%date{yyyyMMdd-HH:mm:ss.fff},UTC=%utcdate{yyyyMMdd-HH:mm:ss.fff},DELTA=%10timestamp,THR=%thread,%-5level,%message%newline" />
       </layout>
     </appender>
 

--- a/ReadMe.MD
+++ b/ReadMe.MD
@@ -2,23 +2,23 @@
 
 ## Description
 
-This project is a minimal set of files to implement Log4Net logging in AspNetCore.
+This project is a minimal set of files to implement Log4Net file appender logging in AspNetCore.
 AspNetCore uses dependency injection to provide logging, and this code implements the required ILogger and ILoggerFactory interfaces.
 The code is thread-safe, and has a single dedicated logging thread for improved performance.
 
 
- 
 ## Quick Start
 
  - NuGet Log4Net
  - Add this project's files to your project in a folder called 'Logging'
  - Add "using NZ01;" to your StartUp.cs class
  - Add "loggerFactory.AddLog4Net();" to StartUp.Configure()
+ - Add "NZ01.Log4NetAsyncLog.Stop();" to the end of Program.Main()
  - In your class to log, add a member variable of type ILogger.
  - In your class to log, populate the member variable using an instance ctor parameter.
  - In your class to log member function, call ILogger.Log<T> or ILogger.LogInformation() to write.
  - Consider direct logging in speed sensitive operations.
- - Locate log file in Logs subdirectory.
+ - Locate log file in ./Logs subdirectory.
  
 See Usage section below for details.
 
@@ -29,8 +29,12 @@ A single thread is established for the lifetime of the application.
 The thread is used to consume objects that are stored on a concurrent queue.
 Event signalling is used so that the queue is only consumed when a new object is enqueued, which means there is no polling of the queue.
 
+Log entries created through the ILogger interface record the calling class.
+Log entries created directly through the static interface do not automatically log the class, and the class should be logged as part of the message.
+
 The design aim was to provide logging which would not impact performance in any way, so that it could be turned on or off in-the-running without disturbing normal production operation.
 As only a single, dedicated thread is used, you will not get any thread starvation.
+
 
 
 ## Contents
@@ -40,13 +44,15 @@ As only a single, dedicated thread is used, you will not get any thread starvati
 #### Log4NetProvider.cs
     
 This file is an implementation of ILoggerProvider.  
-It loads the config, creates the logger and provides access to the logger to the rest of the app.
+It loads the config, creates the ILogger objects and provides access to the ILoggers to the rest of the app.
+There should be one ILogger object created per class that uses a logger via injection.
+ILogger objects are stored in a concurrent dictionary.
 
 
 #### Log4NetLogger.cs
 
 This file is an implementation of ILogger.
-The main function is to overload the Log<T> function so that it loads the concurrent queue of data to log.
+The main function is to overload the Log<T> function so that it loads the singleton concurrent queue of data to log.
 
 
 #### Log4NetExtensions.cs
@@ -62,7 +68,7 @@ This class allows you to set the Log4Net logging level in the running.
 #### Log4NetAsyncLog.cs
 
 This is the main chunk of code.
-It consists of a class to define the object that is queued, and a class to set up the thread, the queue, and to consume the queue.
+It consists of a class to define the wrapper object that is queued, and a class to set up the thread, the queue, and to consume the queue.
 
 
 ### Configuration
@@ -94,8 +100,11 @@ Requires Log4Net module, available on NuGet.
 
  - Add Log4Net using NuGet
  - Add this project's files to your project in a folder like 'Logging'
- - Add "using NZ01;" to your StartUp.cs class
- - Add "loggerFactory.AddLog4Net();" to StartUp.Configure()
+ - Add "using NZ01;" to your Startup.cs class
+ - Add "loggerFactory.AddLog4Net();" to Startup.Configure()
+ - Add "NZ01.Log4NetAsyncLog.Stop();" to the end of Program.Main().  This is not critical, but it will gracefully terminate the log thread and write an exit message to the log.
+ - Use Dependency Injection or direct static access to log messages that default to a file in ".\Logs"
+ 
 
 ### Dependency Injection (Slow)
 
@@ -113,7 +122,7 @@ In your controller or class that you wish to log from:
  
        private void Boom()
        {
-           string wouldLogThis = "BOOM!!";
+           string wouldLogThis = "OMG Something Happened!";
 
            // Using the MS simplified wrapper:
            _logger.LogInformation(prefix + wouldLogThis);
@@ -122,20 +131,23 @@ In your controller or class that you wish to log from:
            _logger.Log<string>(LogLevel.Debug, 0, wouldLogThis, null, ((x,ex) => x.ToString() + " " + ex.ToString()));
            _logger.Log<string>(LogLevel.Information, 0, wouldLogThis, null, NZ01.Log4NetLogger.MyOwnFormatter);
        }
+       
+
  
 ### Direct (Fast)
 
 [Fast? Logging 10000 text lines in a loop with ILogger took 24 seconds, logging directly using this method was sub-second for all 10000 lines.  Seriously, something is currently wrong in ILogger, but no doubt MS will fix this, you know, sometime...]
 
- - In a member function you wish to log from, get a reference to the static instance of the logger, and call the standard Log4Net log function on it.   
+ - In a member function you wish to log from, make direct static calls to standard Log4Net functions ie Debug/Info/Warn/Error/Fatal on the logger.  This still only loads the concurrent queue and therefore it is threadsafe.  The function names are replicated for convenience only.
+ 
  
        private void Boom()
        {
-           string wouldLogThis = "BOOM!!!";
-          
-           NZ01.Log4NetAsyncLog directLog = NZ01.Log4NetAsyncLog.GetLog4NetAsyncLogByName("App");
+           string prefix = "MyClass.Boom(),";
            
-           directLog?.Debug(wouldLogThis); 
+           string wouldLogThis = "OMG Something Happened!";           
+                     
+           NZ01.Log4NetAsyncLog.Debug(prefix + wouldLogThis); 
        }
 
 
@@ -150,10 +162,12 @@ The thinking is that if you have a process (or processes) that is/are able to ru
 There are some diagnostics in the files to record the number of calls to various functions, which are harmless and can be removed if you want.
 
 
-### Queue Size is Logged Too
+### Queue size and Thread are Logged
 
 Note that the size of the queue is logged when the data is enqueued and dequeued.
 This can give you additional clues as to what is happening in the application.
+
+Also, the enqueuing thread is logged (the thread making the call to log), making this useful when trying to see what is happening on various simultaneous threads.
 
 
 ### In-The-Running Changes
@@ -162,29 +176,31 @@ Log level can be changed whilst the app is running if you call the static NZ01.L
 The idea is that you hook up an admin-only API action to this function, and pass a log level.  
 You can then shift from INFO to DEBUG log level with an API call, which you can, of course, trigger from a web page, or however you need.
 
+What we have lost here is the Log4Net ability to set a log level per instance of Log4Net logger, and therefore an independent log threshold level per class.
+I prefer too much info to too little, and the ability to switch the log level for the whole app is something I prefer.
+
 
 ### Stopping
 
 There is a static Stop() function that will gracefully stop the logging thread.
-However, AspNetCore does not yet (June 2017) signal correctly that it is stopping.
+
+Web Apps in AspNetCore do not yet (June 2017) signal correctly that the app is stopping.
 Startup.Configure() is supposed to take an IApplicationLifetime parameter, and you can use this to register callback functions that are called when the application starts and stops.  
 However, MS have some kind of bug going on and the Stopping and Stopped callbacks do not fire.
-But, if they did, you would call Stop() function on the logger and this would terminate the dedicated thread and write something mellow to the log file.
-You could still implement this, and when MS get their application lifetime stuff working, your code will silently pick up the change.
-For now though, hard killing the app does no harm.
 
+As a useful work around, it is important to remember that Core apps are now console apps, and have a Main() function.
+You can stop the thread in both Web Apps and Console Apps by making a call to the static function Log4NetAsyncLog.Stop() as the last line of Main().
+You do not have to do this, but calling this function writes a positive message to the log file and shows that the app exited gracefully.
+This can be useful for discriminating between crashes, and user-initiated exits.
+Failure to call to Stop() should not cause any problems, but you would lose this diagnostic element.
 
-### Console Logging
-
-The Log4NetAsyncLog class ctor will take a bConsoleWrite parameter, that is by default set false.
-If this is true, the code will write to the log file as usual, and also issue a Console.Write() of the data being logged.
-This is largely redundant as Console logging is now handled in an out-of-the-box unit from Microsoft, but it's there anyway, just ignore it.
 
 
 
 ## Licensing
 
 Use as you see fit, but donate something to Second Chance Tasman Cats and Dogs Home if your conscience is bothering you.
+
  - https://www.facebook.com/secondchancetasman/
 
 
@@ -192,4 +208,4 @@ Use as you see fit, but donate something to Second Chance Tasman Cats and Dogs H
 ## The Last Word
 
 Any bugs, let me know, I use this in anger so it would be good to have feedback.
-Shoot me in the head as AvidFan on Destiny/XBox.
+Angrily shoot me in the head as AvidFan on Destiny/XBox.


### PR DESCRIPTION
BRANCH: 2017-06-27_LT3_StaticRework


CHANGED: Logging/log4Net/Log4NetAsyncLog.cs
 - Most of the class made static.
 - Thread no longer has a name.

CHANGED: Logging/log4Net/Log4NetExtensions.cs
 - Config file now hard-wired, overload removed.

CHANGED: Logging/log4Net/Log4NetLogger.cs
 - Logger now instanced to store class name.

CHANGED: Logging/log4Net/Log4NetProvider.cs
 - Instances of Logger are stored in concurrent Dictionary.
 - Creating a logger either gets or adds a new logger.
 - Running flag stops addition of logs after dispose is called.

CHANGED: ReadMe.MD
 - Additional Stop() instructions added.
 - Static calls updated to new format.
 - Console logging removed.

CHANGED: Logging/log4Net/log4Net.config
CHANGED: Logging/log4Net/log4Net_DateLogFile.config
CHANGED: Logging/log4Net/log4Net_SameFileEachRun.config
 - Filename patterns updated.
 - Redundant logger info removed.