### PR TITLE
Remove Log4Net config SMTP reference;

### DIFF
--- a/Logging/log4Net/log4Net.config
+++ b/Logging/log4Net/log4Net.config
@@ -3,7 +3,6 @@
       <!-- RELEASE POINT: AMEND TO INFO -->
       <level value="DEBUG" />
       <appender-ref ref="LogFileAppender" />
-      <appender-ref ref="SmtpAppender" />
     </root>
 
     <appender name="LogFileAppender" type="log4net.Appender.RollingFileAppender">


### PR DESCRIPTION
BRANCH: 2017-06-28_LT3_ConfigTidy

CHANGED: Logging/log4Net/log4Net.config
 - Removed redundant SMTP reference.