### PR TITLE
Correction to missing static declaration for ThresholdLevelError() fn;

### DIFF
--- a/Logging/log4Net/Log4NetAsyncLog.cs
+++ b/Logging/log4Net/Log4NetAsyncLog.cs
@@ -275,7 +275,7 @@ namespace NZ01
         public static int ThresholdLevelWarn()
         { return _thresholdLevelWarn; }
 
-        public int ThresholdLevelError(int qSize)
+        public static int ThresholdLevelError(int qSize)
         {
             _thresholdLevelError = qSize;
             setQSizeFormatter();


### PR DESCRIPTION
BRANCH: 2017-07-27_LT3_StaticMissing_Correction

CHANGED: Logging/log4Net/Log4NetAsyncLog.cs
 - ThresholdLevelError() was not declared static, now corrected.