### PR TITLE
Log4NetExtensions renamed (was Log4netExtensions);

### DIFF
--- a/Log4NetCore/Log4NetCore/Logging/log4Net/Log4NetExtensions.cs
+++ b/Log4NetCore/Log4NetCore/Logging/log4Net/Log4NetExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace NZ01
 {
-    public static class Log4netExtensions
+    public static class Log4NetExtensions
     {
         public static int CountCalls_AddLog4Net { get; set; } = 0;
 


### PR DESCRIPTION
BRANCH: 2017-08-07_LT3_Log4NetExtensions_Renamed

CHANGED: Log4NetCore/Log4NetCore/Logging/log4Net/Log4NetExtensions.cs
 - Class renamed to make capitalisation consistent